### PR TITLE
provide a vec method for operators

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -110,10 +110,10 @@ SUITE["Block, homogeneous"]["domain"] = @benchmarkable domain($F)
 SUITE["Block, homogeneous"]["range"] = @benchmarkable range($F)
 SUITE["Block, homogeneous"]["block"] = @benchmarkable getblock($m, 2)
 SUITE["Block, homogeneous"]["block!"] = @benchmarkable setblock!($m, 2, $(rand(100)))
-SUITE["Block, homogeneous"]["broadcast"] = @benchmarkable f .= d .+ e
-SUITE["Block, homogeneous"]["broadcast (base-case)"] = @benchmarkable f′ .= d′ .+ e′
-SUITE["Block, homogeneous"]["fill!"] = @benchmarkable f .= $(rand())
-SUITE["Block, homogeneous"]["fill! (base-case)"] = @benchmarkable f′ .= $(rand())
+SUITE["Block, homogeneous"]["broadcast"] = @benchmarkable $f .= $d .+ $e
+SUITE["Block, homogeneous"]["broadcast (base-case)"] = @benchmarkable $f′ .= $d′ .+ $e′
+SUITE["Block, homogeneous"]["fill!"] = @benchmarkable $f .= $(rand())
+SUITE["Block, homogeneous"]["fill! (base-case)"] = @benchmarkable $f′ .= $(rand())
 SUITE["Block, homogeneous"]["dot"] = @benchmarkable dot($d, $e)
 SUITE["Block, homogeneous"]["dot (base-case)"] = @benchmarkable dot($d′, $e′)
 SUITE["Block, homogeneous"]["norm"] = @benchmarkable norm($d)
@@ -149,10 +149,38 @@ SUITE["Block, heterogeneous"]["domain"] = @benchmarkable domain($F)
 SUITE["Block, heterogeneous"]["range"] = @benchmarkable range($F)
 SUITE["Block, heterogeneous"]["block"] = @benchmarkable getblock($m, 2)
 SUITE["Block, heterogeneous"]["block!"] = @benchmarkable setblock!($d, 2, $(rand(100)))
-SUITE["Block, heterogeneous"]["broadcast"] = @benchmarkable f .= d .+ e
-SUITE["Block, heterogeneous"]["broadcast (base-case)"] = @benchmarkable f′ .= d′ .+ e′
-SUITE["Block, heterogeneous"]["fill!"] = @benchmarkable f .= $(rand())
-SUITE["Block, heterogeneous"]["fill! (base-case)"] = @benchmarkable f′ .= $(rand())
+SUITE["Block, heterogeneous"]["broadcast"] = @benchmarkable $f .= $d .+ $e
+SUITE["Block, heterogeneous"]["broadcast (base-case)"] = @benchmarkable $f′ .= $d′ .+ $e′
+SUITE["Block, heterogeneous"]["fill!"] = @benchmarkable $f .= $(rand())
+SUITE["Block, heterogeneous"]["fill! (base-case)"] = @benchmarkable $f′ .= $(rand())
 SUITE["Block, heterogeneous"]["reshape"] = @benchmarkable reshape($d′, $rangeF)
+
+JopBaz_df!(d,m;diagonal,kwargs...) = d .= diagonal .* m
+function JopBaz(diag)
+    spc = JetSpace(Float64, size(diag))
+    JopLn(;df! = JopBaz_df!, dom = spc, rng = spc, s = (diagonal=diag,))
+end
+F = JopBaz(rand(10,10))
+rng = range(F)
+Fvec = vec(F)
+J = jacobian(F, m)
+Jvec = vec(J)
+m = rand(domain(F))
+d = rand(range(F))
+mvec = vec(m)
+dvec = vec(d)
+SUITE["vec"] = BenchmarkGroup()
+SUITE["vec"]["construct"] = @benchmarkable vec($F)
+SUITE["vec"]["mul!"] = @benchmarkable mul!($dvec, $Fvec, $mvec)
+SUITE["vec"]["mul"] = @benchmarkable $Fvec * $mvec
+SUITE["vec"]["jacobian"] = @benchmarkable jacobian!($Fvec, $mvec)
+SUITE["vec"]["mul!, adjoint"] = @benchmarkable mul!($mvec, ($Jvec)', $dvec)
+SUITE["vec"]["mul, adjoint"] = @benchmarkable ($Jvec)' * $dvec
+SUITE["vec"]["adjoint"] = @benchmarkable ($Jvec)'
+SUITE["vec"]["shape"] = @benchmarkable shape($Fvec)
+SUITE["vec"]["size"] = @benchmarkable size($Fvec)
+SUITE["vec"]["domain"] = @benchmarkable domain($Fvec)
+SUITE["vec"]["range"] = @benchmarkable range($Fvec)
+SUITE["vec"]["vec range"] = @benchmarkable vec($rng)
 
 SUITE

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -71,6 +71,7 @@ ones(R)       # array of ones with the element-type and size of `R`
 rand(R)       # random array with the element-type and size of `R`
 zeros(R)      # zero array with the element-type and size of `R`
 Array(R)      # uninitialized array with the element-type and size of `R`
+vec(R)        # return a similar space, but backed by a one dimensional array
 ```
 
 ## Jets
@@ -206,6 +207,21 @@ _d = rand(eltype(range(A)), size(range(A)))
 d = reshape(_d, range(A))
 ```
 Since `BlockArrays` extend Julia's `AbstractArray` and broadcasting interfaces, most of the functionality of a Julia `Array` is also available for `BlockArray`'s.
+
+## Vectorized operators
+There are libraries that assume that the vectors in the model and data space are backed by one dimensional arrays.  To help with this, Jets provides
+a `vec` method that returns an operator with one dimensional arrays backing the domain and range.  As an example, we show how to compose Jets with
+the `lsqr` method in the IterativeSolvers package.
+```julia
+using Jets, JetPack, IterativeSolvers
+
+A = JopDct(Float64, 128, 64)
+d = rand(range(A))
+m = reshape(lsqr(vec(A), vec(d)), range(A))
+A*m ≈ d # true
+```
+Note that for the case that the domain and range are already backed by one dimensional arrays, `vec` is a no-op.  Further, note that a block array
+is a one dimensional array.  
 
 ## Creating a new Jet (Developers) 
 To build a new jet, provide the function that maps from the domain to the range, its linearization and a default state. We will show three examples: 1) linear operator, 2) self-adjoint linear operator, 3) nonlinear operator.


### PR DESCRIPTION
This allows us to use vectorized input arrays, but that will be reshaped to match what is expected by the operator author.  This is an alternative to #8, and which I think is also an improvement over #8.  With this change, interaction with methods that expect 1D arrays (e.g. IterativeSolvers.lsqr) will look like this:

```julia
using Jets, JetPack, IterativeSolvers

A = JopDiagonal(rand(50,50) .+ 0.2)
d = rand(range(A))

m = reshape(lsqr(vec(A), vec(d); atol=1e-9, btol=1e-9), domain(A))
A*m ≈ d # True
```

cc: @mloubout,  @philippwitte, @jkwashbourne, @flexie